### PR TITLE
fix: Update gcra naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 |:----------------------------|:----:|:-------:|
 | Leaky Bucket                | Yes  |   TBD   |
 | Token Bucket                | Yes  |   TBD   |
-| Generic Cell Rate Algorithm | TBD  |   TBD   |
+| Generic Cell Rate Algorithm | Yes  |   TBD   |
 | LLM-Token                   | TBD  |   TBD   |
 
 > [!NOTE]  
@@ -154,13 +154,13 @@ from datetime import datetime
 
 from rate_limit.generic_cell_rate import (
     GCRAConfig,
-    LeakyBucketGCRA,
-    VirtualSchedulingGCRA,
+    SyncLeakyBucketGCRA,
+    SyncVirtualSchedulingGCRA,
 )
 
 # 3 requests per 1.5 seconds and a 3 second burst capacity
 config = GCRAConfig(capacity=3, seconds=1.5)
-context_sync = LeakyBucketGCRA(config)  # can swap with VirtualSchedulingGCRA
+context_sync = SyncLeakyBucketGCRA(config)  # can swap with VirtualSchedulingGCRA
 for _ in range(12):
     with context_sync as thing:
         print(f"Current level {_} sent at {datetime.now().strftime('%X.%f')}")
@@ -173,13 +173,13 @@ from datetime import datetime
 
 from rate_limit.generic_cell_rate import (
     GCRAConfig,
-    LeakyBucketGCRA,
-    VirtualSchedulingGCRA,
+    SyncLeakyBucketGCRA,
+    SyncVirtualSchedulingGCRA,
 )
 
 # 10 requests per 5 seconds and a 10 second burst capacity
 config = GCRAConfig(capacity=10, seconds=5)
-sync_bucket = LeakyBucketGCRA(config)  # can swap with VirtualSchedulingGCRA
+sync_bucket = SyncLeakyBucketGCRA(config)  # can swap with SyncVirtualSchedulingGCRA
 for i in range(12):
     if i % 2 == 0:
         sync_bucket.acquire(1)

--- a/rate_limit/generic_cell_rate/core.py
+++ b/rate_limit/generic_cell_rate/core.py
@@ -31,7 +31,7 @@ class GCRAConfig:
             raise ValueError("capacity must be at least 1")
 
 
-class VirtualSchedulingGCRA:
+class SyncVirtualSchedulingGCRA:
     """Virtual Scheduling Generic Cell Rate Algorithm Rate Limiter
 
     Args:
@@ -84,7 +84,7 @@ class VirtualSchedulingGCRA:
 
         self._tat = max(t_a, self._tat) + amount * self.T
 
-    def __enter__(self) -> VirtualSchedulingGCRA:
+    def __enter__(self) -> SyncVirtualSchedulingGCRA:
         """Enter the context manager, acquiring resources if necessary
 
         Returns:
@@ -104,7 +104,7 @@ class VirtualSchedulingGCRA:
         return None
 
 
-class LeakyBucketGCRA:
+class SyncLeakyBucketGCRA:
     """Continuous-state Leaky Bucket Rate Limiter
 
     Args:
@@ -165,7 +165,7 @@ class LeakyBucketGCRA:
         self._bucket_level = max(0.0, self._bucket_level) + amount * self.T
         self._last_leak = t_a
 
-    def __enter__(self) -> LeakyBucketGCRA:
+    def __enter__(self) -> SyncLeakyBucketGCRA:
         """Enter the context manager, acquiring resources if necessary
 
         Returns:


### PR DESCRIPTION
- Update the class names to have `Sync` in the name for the Generic Cell Rate Algorithm classes. Forgot to do this
- Check the box in the README that we completed the synchronous generic cell rate algorithm rate limiter