### PR TITLE
fix: pypi url

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
+      pypi_ulr: ${{ steps.pypi.outputs.pypi_url }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -38,9 +39,9 @@ jobs:
         id: pypi
         run: |
           if [[ "$IS_PRERELEASE" == "true" ]]; then
-            echo "PYPI_URL=https://test.pypi.org/legacy/" >> "$GITHUB_ENV"
+            echo "pypi_url=https://test.pypi.org/legacy/" >> "$GITHUB_ENV"
           else
-            echo "PYPI_URL=https://upload.pypi.org/legacy/" >> "$GITHUB_ENV"
+            echo "pypi_url=https://upload.pypi.org/legacy/" >> "$GITHUB_ENV"
           fi
 
       - name: Create GitHub Release
@@ -72,7 +73,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-          python-version-file: ".python-version"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
@@ -89,4 +89,4 @@ jobs:
       - name: Publish to PyPI using uv
         run: uv publish
         env:
-          UV_PUBLISH_URL: ${{ env.PYPI_URL }}
+          UV_PUBLISH_URL: ${{ needs.create-release.outputs.pypi_url }}

--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,4 @@ cython_debug/
 # Custom for this project
 exploration/
 notebooks/
+*_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=64", "setuptools-scm>=8.1"]
+requires = ["setuptools>=80", "setuptools-scm[simple]>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
- Fixes the pypi url in the github actions
- Modifies the setuptools-scm versions

I will say there has been a lot of thrash with the last few PRs. There seem to be a ton of contradictions in official setuptools docs for publishing packages vs official docs on pyproject.toml files vs setuptools-scm (non-trivial differences in the website vs README for instance)...just unfortunate