### PR TITLE
feat: build badges v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,8 @@ name: Continuous Integration
 on:
   pull_request:
     types: [opened, reopened, synchronize]
-    #branches: [main]
+  push:
+    branches: [main]
 
   workflow_dispatch:
 
@@ -66,12 +67,12 @@ jobs:
         run: |
           uv run pytest --cov --cov-branch --cov-report=xml
         if: |
-          matrix.os == 'ubuntu-latest'
+          github.event_name == 'push' && github.ref == 'refs/heads/main'
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         if: |
-          matrix.os == 'ubuntu-latest'
+          github.event_name == 'push' && github.ref == 'refs/heads/main'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [build-url]: https://github.com/jrinder42/rate-limit/actions/workflows/ci.yml
 [doc-image]: https://img.shields.io/badge/docs-link-blue
 [doc-url]: https://jrinder42.github.io/rate-limit/
-[coverage-image]: https://codecov.io/gh/jrinder42/rate-limit/branch/main/graph/badge.svg
+[coverage-image]: https://codecov.io/gh/jrinder42/rate-limit/graph/badge.svg
 [coverage-url]: https://codecov.io/gh/jrinder42/rate-limit
 [version-image]: https://img.shields.io/pypi/pyversions/limitor
 


### PR DESCRIPTION
Add push to main for the CI build step. This is a bit redundant as if it passes on a branch, it will also pass in main. This is more for:
1. Needed to get the code coverage of the main branch --> eventually can see if there are regression between a branch and main
2. If QA vs PROD ever exists (QA for a branch and PROD for the main branch)