### PR TITLE
chore: update integration tests to be more robust

### DIFF
--- a/tests/integration/test_integration_async.py
+++ b/tests/integration/test_integration_async.py
@@ -116,7 +116,7 @@ class TestAmountValidation:
             await bucket_cls.acquire(1)
             value_list.append(value + 1)
 
-        assert len(asyncio_sleep_calls) == 4
+        assert len(asyncio_sleep_calls) >= 4  # possibility of some extra sleeps depending on OS timing
         assert value_list == [1, 2, 3, 4, 5, 6]
 
     async def test_acquire_variable_amount_multiple(
@@ -128,7 +128,7 @@ class TestAmountValidation:
             await bucket_cls.acquire(1 if value % 2 == 0 else 2)
             value_list.append(1 if value % 2 == 0 else 2)
 
-        assert len(asyncio_sleep_calls) == 5
+        assert len(asyncio_sleep_calls) >= 5
         assert value_list == [1, 2, 1, 2, 1, 2]  # assert order is correct
 
 
@@ -151,7 +151,7 @@ async def test_decorator_calls_acquire(bucket_cls: type[AsyncRateLimit], asyncio
     for value in range(6):
         value_list.append(await something(value))  # amount defaults to 1
 
-    assert len(asyncio_sleep_calls) == 4
+    assert len(asyncio_sleep_calls) >= 4
     assert value_list == [1, 2, 3, 4, 5, 6]  # assert order is correct
 
 
@@ -164,13 +164,13 @@ async def test_context_manager_calls_acquire(bucket_cls: AsyncRateLimit, asyncio
         async with bucket_cls:
             value_list.append(value + 1)  # just acquire and release, amount defaults to 1
 
-    assert len(asyncio_sleep_calls) == 4
+    assert len(asyncio_sleep_calls) >= 4
     assert value_list == [1, 2, 3, 4, 5, 6]  # assert order is correct
 
 
 @pytest.mark.asyncio
 async def test_shutdown_without_starting_worker(bucket_config: BucketConfig) -> None:
-    """Shutdown should be a no-op if the worker was never started."""
+    """Shutdown should be a no-op if the worker was never started"""
     bucket = AsyncLeakyBucketExtra(bucket_config)
     # worker should not be started at construction time
     assert bucket._worker_task is None  # pylint: disable=protected-access

--- a/tests/integration/test_integration_sync.py
+++ b/tests/integration/test_integration_sync.py
@@ -80,7 +80,7 @@ class TestAmountValidation:
             bucket_cls.acquire(1)
             value_list.append(value + 1)
 
-        assert len(sleep_calls) == 4
+        assert len(sleep_calls) >= 4  # possibility of some extra sleeps depending on OS timing
         assert value_list == [1, 2, 3, 4, 5, 6]
 
     def test_acquire_variable_amount_multiple(self, bucket_cls: SyncRateLimit, sleep_calls: list[float]) -> None:
@@ -90,7 +90,7 @@ class TestAmountValidation:
             bucket_cls.acquire(1 if value % 2 == 0 else 2)
             value_list.append(1 if value % 2 == 0 else 2)
 
-        assert len(sleep_calls) == 5
+        assert len(sleep_calls) >= 5
         assert value_list == [1, 2, 1, 2, 1, 2]  # assert order is correct
 
 
@@ -112,7 +112,7 @@ def test_decorator_calls_acquire(bucket_cls: type[SyncRateLimit], sleep_calls: l
     for value in range(6):
         value_list.append(something(value))  # amount defaults to 1
 
-    assert len(sleep_calls) == 4
+    assert len(sleep_calls) >= 4
     assert value_list == [1, 2, 3, 4, 5, 6]  # assert order is correct
 
 
@@ -124,5 +124,5 @@ def test_context_manager_calls_acquire(bucket_cls: SyncRateLimit, sleep_calls: l
         with bucket_cls:
             value_list.append(value + 1)  # just acquire and release, amount defaults to 1
 
-    assert len(sleep_calls) == 4
+    assert len(sleep_calls) >= 4
     assert value_list == [1, 2, 3, 4, 5, 6]  # assert order is correct


### PR DESCRIPTION
Sometimes due to Operating System (OS) timing, we can get more loops than expected regarding how long to wait. Instead of testing we have `x` number of sleep calls, we instead set this to a lower bound that is guaranteed