### PR TITLE
Revert "fix: protocol structure"

### DIFF
--- a/limitor/base.py
+++ b/limitor/base.py
@@ -39,7 +39,6 @@ class SyncRateLimit(Protocol):
         Returns:
             An instance of the rate limit context manager
         """
-        return self
 
     def __exit__(self, exc_type: type[BaseException], exc_val: BaseException, exc_tb: TracebackType) -> None:
         """Exit the context manager, releasing any resources if necessary
@@ -77,7 +76,6 @@ class AsyncRateLimit(Protocol):
         Returns:
             An instance of the rate limit context manager
         """
-        return self
 
     async def __aexit__(self, exc_type: type[BaseException], exc_val: BaseException, exc_tb: TracebackType) -> None:
         """Exit the context manager, releasing any resources if necessary


### PR DESCRIPTION
Reverts jrinder42/rate-limit#65

Basedpyright complains about this, but it seems to ignore the fact that it is a protocol and we shouldn't have a return value, just an outline