### PR TITLE
fix: protocol method with non-none return type

### DIFF
--- a/limitor/base.py
+++ b/limitor/base.py
@@ -39,7 +39,7 @@ class SyncRateLimit(Protocol):
         Returns:
             An instance of the rate limit context manager
         """
-        ...
+        ...  # pylint: disable=unnecessary-ellipsis
 
     def __exit__(self, exc_type: type[BaseException], exc_val: BaseException, exc_tb: TracebackType) -> None:
         """Exit the context manager, releasing any resources if necessary
@@ -77,7 +77,7 @@ class AsyncRateLimit(Protocol):
         Returns:
             An instance of the rate limit context manager
         """
-        ...
+        ...  # pylint: disable=unnecessary-ellipsis
 
     async def __aexit__(self, exc_type: type[BaseException], exc_val: BaseException, exc_tb: TracebackType) -> None:
         """Exit the context manager, releasing any resources if necessary


### PR DESCRIPTION
If a return type in a protocol is not `None`, you have to add the ellipses (...) to the method