### PR TITLE
fix: modify pytest caching strategy + comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
 
       # Testing with a cache
 
-      # Restore the testmon db from the previous run
+      # Restore the testmon db from the previous run. On branches, read-only. On main, read-write
       - name: Restore Testmon DB
         uses: actions/cache/restore@v5
         id: restore-testmon
@@ -122,21 +122,22 @@ jobs:
       - name: Run tests
         run: |
           echo "Running tests with pytest-testmon..."
-          # If no cache found (first run), this runs ALL tests.
+          # If no cache found (first run), this runs ALL tests
           uv run pytest tests/ --testmon
 
-      # Delete the old cache if it exists
+      # Delete the old cache if it exists: only on the main branch
       - name: Delete Old Cache
-        if: steps.restore-testmon.outputs.cache-hit == 'true'
+        if: github.ref == 'refs/heads/main'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh cache delete testmon-db-main || true
 
-      # Finally, save the new cache even if some tests fail
+      # Finally, save the new cache even if some tests fail: only on the main branch
       - name: Save Testmon DB
         uses: actions/cache/save@v5
-        if: always()
+        # Only save if we are on main and the delete didn't crash
+        if: github.ref == 'refs/heads/main' && always()
         with:
           path: .testmondata
           key: testmon-db-main


### PR DESCRIPTION
## Steps

1. Restore the cache if it exists
    - On branches (like this), this is read-only i.e. we are only attempting to restore (find and download) the cache
2. Run the tests --> output the .testmondata file i.e. the file to cache
3. Delete the cache file (**ONLY on the default branch**). If this fails to delete a file, just continue along. This would happen if it could not find the cache in step 1 for instance
4. Save the .testmondata file out to the cache only if we are on the default branch. In this case, the `main` branch