### PR TITLE
feat: Branch coverage + update justfile with branch code coverage parameter

### DIFF
--- a/justfile
+++ b/justfile
@@ -97,9 +97,9 @@ all: format lint type-check test
     @echo "All checks passed!"
 
 # code coverage, can also call package_name with {{package_name}}
-coverage:
+coverage branch="false":
     uv run coverage erase
-    uv run coverage run --source $package_name -m pytest -Wignore $test_files
+    uv run coverage run {{ if branch == "true" { "--branch" } else { "" } }} --source $package_name -m pytest -Wignore $test_files
     uv run coverage report -m
     uv run coverage xml
 

--- a/tests/unit/test_async.py
+++ b/tests/unit/test_async.py
@@ -412,3 +412,20 @@ async def test_context_manager_calls_acquire_unit(bucket_cls: AsyncRateLimit, mo
 
     # Assert our logic inside the 'with' executed as expected
     assert value_list == [1, 2, 3, 4, 5, 6]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bucket_cls_wait", [AsyncLeakyBucket, AsyncTokenBucket, AsyncLeakyBucketExtra])
+@patch("asyncio.sleep", new_callable=AsyncMock)
+async def test_acquire_wait_time_less_than_or_equal_to_zero(
+    mocked_sleep: AsyncMock, bucket_cls_wait: type[AsyncRateLimit], bucket_config: BucketConfig
+) -> None:
+    """Test the branch where wait_time <= 0 inside the acquire loop"""
+    bucket = bucket_cls_wait(bucket_config=bucket_config)
+    with patch.object(bucket, "capacity_info") as mocked_capacity_info:
+        mocked_capacity_info.side_effect = [
+            Capacity(has_capacity=False, needed_capacity=0),
+            Capacity(has_capacity=True, needed_capacity=0),
+        ]
+        await bucket.acquire(1)
+        mocked_sleep.assert_not_called()

--- a/tests/unit/test_sync.py
+++ b/tests/unit/test_sync.py
@@ -277,3 +277,17 @@ def test_context_manager_calls_acquire_unit(bucket_cls: SyncRateLimit, monkeypat
 
     # Assert our logic inside the 'with' executed as expected
     assert value_list == [1, 2, 3, 4, 5, 6]
+
+
+@pytest.mark.parametrize("bucket_cls_wait", [SyncLeakyBucket, SyncTokenBucket])
+def test_acquire_wait_time_less_than_or_equal_to_zero(
+    bucket_cls_wait: type[SyncRateLimit], bucket_config: BucketConfig
+) -> None:
+    """Test the branch where wait_time <= 0 inside the acquire loop"""
+    bucket = bucket_cls_wait(bucket_config=bucket_config)
+    with patch.object(bucket, "capacity_info") as mocked_capacity_info:
+        mocked_capacity_info.side_effect = [
+            Capacity(has_capacity=False, needed_capacity=0),
+            Capacity(has_capacity=True, needed_capacity=0),
+        ]
+        bucket.acquire(1)


### PR DESCRIPTION
- Add sync + async tests when wait_time <= 0 in order to get 100% branch code coverage
- Add branch parameter to the Justfile to seamlessly switch between regular code coverage and branch code coverage


Regular code coverage
```shell
just coverage
```

Branch code coverage
```shell
just coverage true
```

closes #72 