### PR TITLE
fix: async concurrency restarting on every request

### DIFF
--- a/limitor/generic_cell_rate/core.py
+++ b/limitor/generic_cell_rate/core.py
@@ -10,8 +10,9 @@ from __future__ import annotations
 import asyncio
 import threading
 import time
-from contextlib import nullcontext
+from contextlib import AbstractAsyncContextManager, nullcontext
 from types import TracebackType
+from typing import Any
 
 from limitor.configs import BucketConfig
 from limitor.utils import validate_amount
@@ -202,6 +203,7 @@ class AsyncVirtualSchedulingGCRA:
 
         self.max_concurrent = max_concurrent
         self._lock = asyncio.Lock()
+        self._semaphore: asyncio.Semaphore | AbstractAsyncContextManager[Any] | None = None
 
     async def _acquire_logic(self, amount: float = 1) -> None:
         """Acquire resources, blocking if necessary to conform to the rate limit
@@ -237,8 +239,10 @@ class AsyncVirtualSchedulingGCRA:
         Args:
             amount: The amount of capacity to acquire, defaults to 1
         """
-        semaphore = asyncio.Semaphore(self.max_concurrent) if self.max_concurrent else nullcontext()
-        async with semaphore:
+        if self._semaphore is None:
+            self._semaphore = asyncio.Semaphore(self.max_concurrent) if self.max_concurrent else nullcontext()
+
+        async with self._semaphore:
             await self._acquire_logic(amount)
 
     async def acquire(self, amount: float = 1, timeout: float | None = None) -> None:
@@ -314,6 +318,7 @@ class AsyncLeakyBucketGCRA:
 
         self.max_concurrent = max_concurrent
         self._lock = asyncio.Lock()
+        self._semaphore: asyncio.Semaphore | AbstractAsyncContextManager[Any] | None = None
 
     async def _acquire_logic(self, amount: float = 1) -> None:
         """Acquire resources, blocking if necessary to conform to the rate limit
@@ -357,8 +362,10 @@ class AsyncLeakyBucketGCRA:
         Args:
             amount: The amount of capacity to acquire, defaults to 1
         """
-        semaphore = asyncio.Semaphore(self.max_concurrent) if self.max_concurrent else nullcontext()
-        async with semaphore:
+        if self._semaphore is None:
+            self._semaphore = asyncio.Semaphore(self.max_concurrent) if self.max_concurrent else nullcontext()
+
+        async with self._semaphore:
             await self._acquire_logic(amount)
 
     async def acquire(self, amount: float = 1, timeout: float | None = None) -> None:

--- a/limitor/leaky_bucket/core.py
+++ b/limitor/leaky_bucket/core.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import asyncio
 import threading
 import time
-from contextlib import nullcontext
+from contextlib import AbstractAsyncContextManager, nullcontext
 from types import TracebackType
+from typing import Any
 
 from limitor.configs import BucketConfig, Capacity
 from limitor.utils import validate_amount
@@ -116,6 +117,7 @@ class AsyncLeakyBucket:
 
         self.max_concurrent = max_concurrent
         self._lock = asyncio.Lock()
+        self._semaphore: asyncio.Semaphore | AbstractAsyncContextManager[Any] | None = None
 
     def _leak(self) -> None:
         """Leak the bucket based on the elapsed time since the last leak"""
@@ -171,8 +173,10 @@ class AsyncLeakyBucket:
         Args:
             amount: The amount of capacity to acquire, defaults to 1
         """
-        semaphore = asyncio.Semaphore(self.max_concurrent) if self.max_concurrent else nullcontext()
-        async with semaphore:
+        if self._semaphore is None:
+            self._semaphore = asyncio.Semaphore(self.max_concurrent) if self.max_concurrent else nullcontext()
+
+        async with self._semaphore:
             await self._acquire_logic(amount)
 
     async def acquire(self, amount: float = 1, timeout: float | None = None) -> None:

--- a/limitor/token_bucket/core.py
+++ b/limitor/token_bucket/core.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import asyncio
 import threading
 import time
-from contextlib import nullcontext
+from contextlib import AbstractAsyncContextManager, nullcontext
 from types import TracebackType
+from typing import Any
 
 from limitor.configs import BucketConfig, Capacity
 from limitor.utils import validate_amount
@@ -118,6 +119,7 @@ class AsyncTokenBucket:
 
         self.max_concurrent = max_concurrent
         self._lock = asyncio.Lock()
+        self._semaphore: asyncio.Semaphore | AbstractAsyncContextManager[Any] | None = None
 
     def _fill(self) -> None:
         """Fill the bucket based on the elapsed time since the last fill"""
@@ -174,8 +176,10 @@ class AsyncTokenBucket:
         Args:
             amount: The amount of capacity to acquire, defaults to 1
         """
-        semaphore = asyncio.Semaphore(self.max_concurrent) if self.max_concurrent else nullcontext()
-        async with semaphore:
+        if self._semaphore is None:
+            self._semaphore = asyncio.Semaphore(self.max_concurrent) if self.max_concurrent else nullcontext()
+
+        async with self._semaphore:
             await self._acquire_logic(amount)
 
     async def acquire(self, amount: float = 1, timeout: float | None = None) -> None:

--- a/tests/unit/test_async.py
+++ b/tests/unit/test_async.py
@@ -242,6 +242,12 @@ class TestAsyncFeatures:
             # Check logic was called inside
             mock_logic.assert_called_once_with(1)
 
+            # Check Semaphore is reused on second call
+            await bucket.acquire(amount=1)
+            assert mocked_sem_cls.call_count == 1
+            assert mock_sem_instance.__aenter__.call_count == 2
+            assert mock_sem_instance.__aexit__.call_count == 2
+
     @pytest.mark.parametrize("bucket_cls", [AsyncLeakyBucket, AsyncTokenBucket])
     @patch("time.monotonic", return_value=0)
     @patch("asyncio.sleep", new_callable=AsyncMock)


### PR DESCRIPTION
The current implementation of concurrency controls via an async semaphore doesn't work as it restarts upon every request. This fixes that