### PR TITLE
feat: Token cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,48 +81,70 @@ uv lock --upgrade-package requests
 > [!IMPORTANT]
 > These are special use cases. The general use cases are in the `examples/` folder
 
-### LLM Token-Based Rate Limiting
+### Token & Variable-Amount Rate Limiting (LLM TPM, Batch Sizes)
 
-> [!NOTE]
-> This decorator assumes that the user will pass any necessary params. If you want to make these optional, see `limitor/__init__.py`
+`limitor` natively supports variable-capacity and LLM token-based rate limiting via decorators and context managers using `acquire_ctx()`, `reconcile()`, and optional `token_estimate` / `token_reconcile` decorator hooks.
+
+#### 1. Dynamic Token Estimation with Decorators (LLM Prompt Tokens)
 
 ```python
-from functools import wraps
 import random
 import time
-from typing import Callable
+from limitor import rate_limit
+from limitor.token_bucket.core import SyncTokenBucket
 
-from limitor.base import SyncRateLimit
+# Rate limit of 100,000 tokens per second
+@rate_limit(
+    capacity=100_000,
+    seconds=1,
+    bucket_cls=SyncTokenBucket,
+    token_estimate=lambda prompt, **kw: len(prompt) * 4,  # Estimate tokens from prompt
+)
+def generate_response(prompt: str):
+    print(f"[{time.strftime('%X')}] Generating response for prompt ({len(prompt)*4} tokens)")
+    return f"Response to: {prompt}"
+
+for i in range(10):
+    sample_prompt = "x" * random.randint(1_000, 5_000)
+    generate_response(sample_prompt)
+```
+
+#### 2. Full LLM Prompt Estimation + Response Token Reconciliation
+
+When working with LLM APIs, you can estimate prompt tokens before the request and reconcile with the exact total tokens reported in the API response:
+
+```python
+from limitor import rate_limit
+from limitor.token_bucket.core import SyncTokenBucket
+
+# Automatically debit excess tokens or refund unused tokens
+@rate_limit(
+    capacity=50_000,
+    seconds=60,
+    bucket_cls=SyncTokenBucket,
+    token_estimate=lambda prompt, **kw: len(prompt) // 4,
+    token_reconcile=lambda response: response["usage"]["total_tokens"],
+)
+def query_llm(prompt: str):
+    # Simulated API call returning usage metadata
+    return {"content": "Hello!", "usage": {"total_tokens": 120}}
+```
+
+#### 3. Variable Tokens with Context Managers (`acquire_ctx` & `reconcile`)
+
+```python
 from limitor.configs import BucketConfig
-from limitor.leaky_bucket.core import SyncLeakyBucket
+from limitor.token_bucket.core import SyncTokenBucket
 
+bucket = SyncTokenBucket(BucketConfig(capacity=100_000, seconds=60))
 
-def rate_limit(capacity: int = 10, seconds: float = 1, bucket_cls: type[SyncRateLimit] = SyncLeakyBucket) -> Callable:
-    bucket = bucket_cls(BucketConfig(capacity=capacity, seconds=seconds))
+estimated_tokens = 500
 
-    def decorator(func):
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            amount = kwargs.get("amount", 1)
-            bucket.acquire(amount=amount)
-            return func(*args, **kwargs)
-        return wrapper
-
-    return decorator
-
-# limit of 100,000 tokens per second
-
-@rate_limit(capacity=100_000, seconds=1)
-def process_request(amount=1):
-    print(f"This is a rate-limited function: {time.strftime('%X')} - {amount} tokens")
-
-for _ in range(100):
-    # generate random prompt tokens between 5,000 and 30,000 for 100 sample requests
-    llm_prompt_tokens = random.randint(5_000, 30_000)
-    try:
-        process_request(amount=llm_prompt_tokens)
-    except Exception as error:
-        print(f"Rate limit exceeded: {error}")
+# Acquire custom amount via context manager and reconcile actual usage
+with bucket.acquire_ctx(amount=estimated_tokens):
+    # response = client.chat.completions.create(...)
+    actual_tokens = 450  # e.g. response.usage.total_tokens
+    bucket.reconcile(actual=actual_tokens, estimated=estimated_tokens)
 ```
 
 ### With User-Specific Rate Limits + Cache

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,51 +25,37 @@ Whether you're building APIs, web services, or any other system that requires ra
 
 ## Example Usage
 
-LLM Token Rate Limiting
+### LLM Token Rate Limiting
 
-- System-wide rate limit of 100,000 tokens per second + simulate inputs of varying token amounts 
-
-??? warning "decorator creation"
-
-    This assumes all parameters need to be passed by the end-user. If you want to
-    create a decorator with optional parameters, see `limitor/__init__.py` for an example.
+`limitor` provides native support for variable-capacity and LLM token-based rate limiting via decorators and context managers using `acquire_ctx()`, `reconcile()`, and optional `token_estimate` / `token_reconcile` decorator hooks.
 
 === "Synchronous"
 
+    #### Decorator with Estimation & Reconciliation
+
     ```python
-    from functools import wraps
     import random
     import time
-    from typing import Callable
-    
-    from limitor.base import SyncRateLimit
-    from limitor.configs import BucketConfig
-    from limitor.leaky_bucket.core import SyncLeakyBucket # (1)!
-    
-    
-    def rate_limit(capacity: int = 10, seconds: float = 1, bucket_cls: type[SyncRateLimit] = SyncLeakyBucket) -> Callable:
-        bucket = bucket_cls(BucketConfig(capacity=capacity, seconds=seconds))
-    
-        def decorator(func):
-        
-            @wraps(func)
-            def wrapper(*args, **kwargs):
-                amount = kwargs.get("amount", 1)
-                bucket.acquire(amount=amount)
-                return func(*args, **kwargs)
-            return wrapper
-    
-        return decorator
-    
-    @rate_limit(capacity=100_000, seconds=1)
-    def process_request(amount=1):
-        print(f"This is a rate-limited function: {time.strftime('%X')} - {amount} tokens")
-    
-    for _ in range(100):
-        # generate random prompt tokens between 5,000 and 30,000 for 100 sample requests
-        llm_prompt_tokens = random.randint(5_000, 30_000)
+    from limitor import rate_limit
+    from limitor.token_bucket.core import SyncTokenBucket # (1)!
+
+    # Rate limit of 100,000 tokens per second
+    @rate_limit(
+        capacity=100_000,
+        seconds=1,
+        bucket_cls=SyncTokenBucket,
+        token_estimate=lambda prompt, **kw: len(prompt) * 4,  # Estimate prompt tokens
+        token_reconcile=lambda response: response["usage"]["total_tokens"],  # Reconcile actual usage
+    )
+    def query_llm(prompt: str):
+        # Simulated API call returning usage metadata
+        print(f"[{time.strftime('%X')}] Generating response for {len(prompt)*4} estimated tokens")
+        return {"content": "Response", "usage": {"total_tokens": len(prompt) * 4 + 20}}
+
+    for _ in range(10):
+        prompt = "x" * random.randint(1_000, 5_000)
         try:
-            process_request(amount=llm_prompt_tokens)
+            query_llm(prompt)
         except Exception as error:
             print(f"Rate limit exceeded: {error}")
     ```
@@ -80,47 +66,53 @@ LLM Token Rate Limiting
           - `SyncVirtualSchedulingGCRA`
           - `SyncLeakyBucketGCRA`
 
-=== "Asynchronous"
+    #### Parameterized Context Manager
 
     ```python
-    from functools import wraps
+    from limitor.configs import BucketConfig
+    from limitor.token_bucket.core import SyncTokenBucket
+
+    bucket = SyncTokenBucket(BucketConfig(capacity=100_000, seconds=60))
+    estimated_tokens = 500
+
+    with bucket.acquire_ctx(amount=estimated_tokens):
+        # response = client.chat.completions.create(...)
+        actual_tokens = 480
+        bucket.reconcile(actual=actual_tokens, estimated=estimated_tokens)
+    ```
+
+=== "Asynchronous"
+
+    #### Decorator with Estimation & Reconciliation
+
+    ```python
+    import asyncio
     import random
     import time
-    import asyncio
-    from typing import Callable
-    
-    from limitor.base import AsyncRateLimit
-    from limitor.configs import BucketConfig
-    from limitor.leaky_bucket.core import AsyncLeakyBucket # (1)!
-    
-    
-    def rate_limit(capacity: int = 10, seconds: float = 1, bucket_cls: type[AsyncRateLimit] = AsyncLeakyBucket) -> Callable:
-        bucket = bucket_cls(BucketConfig(capacity=capacity, seconds=seconds))
-    
-        def decorator(func):
-        
-            @wraps(func)
-            async def wrapper(*args, **kwargs):
-                amount = kwargs.get("amount", 1)
-                await bucket.acquire(amount=amount)
-                return await func(*args, **kwargs)
-            return wrapper
-    
-        return decorator
-    
-    @rate_limit(capacity=100_000, seconds=1)
-    async def process_request(amount=1):
-        print(f"This is a rate-limited function: {time.strftime('%X')} - {amount} tokens")
-    
+    from limitor import async_rate_limit
+    from limitor.token_bucket.core import AsyncTokenBucket # (1)!
+
+    # Rate limit of 100,000 tokens per second
+    @async_rate_limit(
+        capacity=100_000,
+        seconds=1,
+        bucket_cls=AsyncTokenBucket,
+        token_estimate=lambda prompt, **kw: len(prompt) * 4,  # Estimate prompt tokens
+        token_reconcile=lambda response: response["usage"]["total_tokens"],  # Reconcile actual usage
+    )
+    async def query_llm(prompt: str):
+        # Simulated async API call returning usage metadata
+        print(f"[{time.strftime('%X')}] Generating response for {len(prompt)*4} estimated tokens")
+        return {"content": "Response", "usage": {"total_tokens": len(prompt) * 4 + 20}}
+
     async def main():
-        for _ in range(100):
-            # generate random prompt tokens between 5,000 and 30,000 for 100 sample requests
-            llm_prompt_tokens = random.randint(5_000, 30_000)
+        for _ in range(10):
+            prompt = "x" * random.randint(1_000, 5_000)
             try:
-                await process_request(amount=llm_prompt_tokens)
+                await query_llm(prompt)
             except Exception as error:
                 print(f"Rate limit exceeded: {error}")
-    
+
     asyncio.run(main())
     ```
 
@@ -129,6 +121,25 @@ LLM Token Rate Limiting
           - `AsyncTokenBucket`
           - `AsyncVirtualSchedulingGCRA`
           - `AsyncLeakyBucketGCRA`
+
+    #### Parameterized Context Manager
+
+    ```python
+    import asyncio
+    from limitor.configs import BucketConfig
+    from limitor.token_bucket.core import AsyncTokenBucket
+
+    async def main():
+        bucket = AsyncTokenBucket(BucketConfig(capacity=100_000, seconds=60))
+        estimated_tokens = 500
+
+        async with bucket.acquire_ctx(amount=estimated_tokens):
+            # response = await client.chat.completions.create(...)
+            actual_tokens = 480
+            await bucket.reconcile(actual=actual_tokens, estimated=estimated_tokens)
+
+    asyncio.run(main())
+    ```
 
 ## References
 

--- a/examples/async/token_rate_limit.py
+++ b/examples/async/token_rate_limit.py
@@ -1,0 +1,45 @@
+import asyncio
+import random
+import time
+
+from limitor import async_rate_limit
+from limitor.configs import BucketConfig
+from limitor.token_bucket.core import AsyncTokenBucket
+
+
+# Rate limit: 10,000 tokens per second
+@async_rate_limit(
+    capacity=10_000,
+    seconds=1,
+    bucket_cls=AsyncTokenBucket,
+    token_estimate=lambda prompt, **kw: len(prompt) * 4,  # Estimate prompt tokens
+    token_reconcile=lambda response: response["usage"]["total_tokens"],  # Reconcile actual tokens
+)
+async def process_llm_request(prompt: str) -> dict:
+    """Simulate rate limited async LLM request."""
+    estimated = len(prompt) * 4
+    actual = estimated + random.randint(10, 50)
+    print(f"[{time.strftime('%X')}] Processed request: {estimated} estimated -> {actual} actual tokens")
+    return {"content": "Response generated", "usage": {"total_tokens": actual}}
+
+
+async def main() -> None:
+    """Run async token rate limiter examples."""
+    print("--- 1. Async Decorator with Token Estimation & Reconciliation ---")
+    for _ in range(5):
+        prompt_text = "sample prompt text " * random.randint(20, 60)
+        await process_llm_request(prompt=prompt_text)
+
+    print("\n--- 2. Async Parameterized Context Manager with Reconciliation ---")
+    bucket = AsyncTokenBucket(BucketConfig(capacity=10_000, seconds=1))
+
+    for _ in range(5):
+        est_tokens = random.randint(500, 2000)
+        async with bucket.acquire_ctx(amount=est_tokens):
+            actual_tokens = est_tokens + random.randint(-50, 100)
+            print(f"[{time.strftime('%X')}] Context manager: {est_tokens} est -> {actual_tokens} actual")
+            await bucket.reconcile(actual=actual_tokens, estimated=est_tokens)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/sync/token_rate_limit.py
+++ b/examples/sync/token_rate_limit.py
@@ -1,0 +1,41 @@
+import random
+import time
+
+from limitor import rate_limit
+from limitor.configs import BucketConfig
+from limitor.token_bucket.core import SyncTokenBucket
+
+print("--- 1. Decorator with Token Estimation & Reconciliation ---")
+
+
+# Rate limit: 10,000 tokens per second
+@rate_limit(
+    capacity=10_000,
+    seconds=1,
+    bucket_cls=SyncTokenBucket,
+    token_estimate=lambda prompt, **kw: len(prompt) * 4,  # Estimate prompt tokens
+    token_reconcile=lambda response: response["usage"]["total_tokens"],  # Reconcile actual tokens
+)
+def process_llm_request(prompt: str) -> dict:
+    """Simulate rate limited LLM request."""
+    estimated = len(prompt) * 4
+    actual = estimated + random.randint(10, 50)  # Completion tokens
+    print(f"[{time.strftime('%X')}] Processed request: {estimated} estimated -> {actual} actual tokens")
+    return {"content": "Response generated", "usage": {"total_tokens": actual}}
+
+
+for i in range(5):
+    prompt_text = "sample prompt text " * random.randint(20, 60)
+    process_llm_request(prompt=prompt_text)
+
+
+print("\n--- 2. Parameterized Context Manager with Reconciliation ---")
+
+bucket = SyncTokenBucket(BucketConfig(capacity=10_000, seconds=1))
+
+for i in range(5):
+    est_tokens = random.randint(500, 2000)
+    with bucket.acquire_ctx(amount=est_tokens):
+        actual_tokens = est_tokens + random.randint(-50, 100)
+        print(f"[{time.strftime('%X')}] Context manager: {est_tokens} est -> {actual_tokens} actual")
+        bucket.reconcile(actual=actual_tokens, estimated=est_tokens)

--- a/limitor/__init__.py
+++ b/limitor/__init__.py
@@ -24,8 +24,8 @@ def rate_limit[**P, R](
     capacity: float = 10,
     seconds: float = 1,
     bucket_cls: type[SyncRateLimit] = SyncLeakyBucket,
-    token_estimate: Callable[P, float] | None = None,
-    token_reconcile: Callable[[R], float] | None = None,
+    token_estimate: Callable[..., float] | None = None,
+    token_reconcile: Callable[..., float] | None = None,
 ) -> Callable[[Callable[P, R]], Callable[P, R]]: ...
 
 
@@ -36,8 +36,8 @@ def rate_limit[**P, R](
     capacity: float = 10,
     seconds: float = 1,
     bucket_cls: type[SyncRateLimit] = SyncLeakyBucket,
-    token_estimate: Callable[P, float] | None = None,
-    token_reconcile: Callable[[R], float] | None = None,
+    token_estimate: Callable[..., float] | None = None,
+    token_reconcile: Callable[..., float] | None = None,
 ) -> Callable[P, R]: ...
 
 
@@ -47,8 +47,8 @@ def rate_limit[**P, R](
     capacity: float = 10,
     seconds: float = 1,
     bucket_cls: type[SyncRateLimit] = SyncLeakyBucket,
-    token_estimate: Callable[P, float] | None = None,
-    token_reconcile: Callable[[R], float] | None = None,
+    token_estimate: Callable[..., float] | None = None,
+    token_reconcile: Callable[..., float] | None = None,
 ) -> Callable[P, R] | Callable[[Callable[P, R]], Callable[P, R]]:
     """Decorator to apply a synchronous rate limit to a function.
 
@@ -99,8 +99,8 @@ def async_rate_limit[**P, R](
     seconds: float = 1,
     max_concurrent: int | None = None,
     bucket_cls: type[AsyncRateLimit] = AsyncLeakyBucket,
-    token_estimate: Callable[P, float] | None = None,
-    token_reconcile: Callable[[R], float] | None = None,
+    token_estimate: Callable[..., float] | None = None,
+    token_reconcile: Callable[..., float] | None = None,
 ) -> Callable[[Callable[P, Awaitable[R]]], Callable[P, Awaitable[R]]]: ...
 
 
@@ -112,8 +112,8 @@ def async_rate_limit[**P, R](
     seconds: float = 1,
     max_concurrent: int | None = None,
     bucket_cls: type[AsyncRateLimit] = AsyncLeakyBucket,
-    token_estimate: Callable[P, float] | None = None,
-    token_reconcile: Callable[[R], float] | None = None,
+    token_estimate: Callable[..., float] | None = None,
+    token_reconcile: Callable[..., float] | None = None,
 ) -> Callable[P, Awaitable[R]]: ...
 
 
@@ -124,8 +124,8 @@ def async_rate_limit[**P, R](
     seconds: float = 1,
     max_concurrent: int | None = None,
     bucket_cls: type[AsyncRateLimit] = AsyncLeakyBucket,
-    token_estimate: Callable[P, float] | None = None,
-    token_reconcile: Callable[[R], float] | None = None,
+    token_estimate: Callable[..., float] | None = None,
+    token_reconcile: Callable[..., float] | None = None,
 ) -> (
     Callable[P, Awaitable[R]]
     | Callable[[Callable[P, Awaitable[R]]], Callable[P, Awaitable[R]]]

--- a/limitor/__init__.py
+++ b/limitor/__init__.py
@@ -24,6 +24,8 @@ def rate_limit[**P, R](
     capacity: float = 10,
     seconds: float = 1,
     bucket_cls: type[SyncRateLimit] = SyncLeakyBucket,
+    token_estimate: Callable[P, float] | None = None,
+    token_reconcile: Callable[[R], float] | None = None,
 ) -> Callable[[Callable[P, R]], Callable[P, R]]: ...
 
 
@@ -34,6 +36,8 @@ def rate_limit[**P, R](
     capacity: float = 10,
     seconds: float = 1,
     bucket_cls: type[SyncRateLimit] = SyncLeakyBucket,
+    token_estimate: Callable[P, float] | None = None,
+    token_reconcile: Callable[[R], float] | None = None,
 ) -> Callable[P, R]: ...
 
 
@@ -43,14 +47,18 @@ def rate_limit[**P, R](
     capacity: float = 10,
     seconds: float = 1,
     bucket_cls: type[SyncRateLimit] = SyncLeakyBucket,
+    token_estimate: Callable[P, float] | None = None,
+    token_reconcile: Callable[[R], float] | None = None,
 ) -> Callable[P, R] | Callable[[Callable[P, R]], Callable[P, R]]:
-    """Decorator to apply a synchronous leaky bucket rate limit to a function.
+    """Decorator to apply a synchronous rate limit to a function.
 
     Args:
-        _func: Function to apply the rate limit to the function
-        capacity: Maximum number of requests allowed in the bucket, defaults to 10
+        _func: Function to apply the rate limit to
+        capacity: Maximum number of requests/tokens allowed in the bucket, defaults to 10
         seconds: Time period in seconds for the bucket to refill, defaults to 1
         bucket_cls: Bucket class, defaults to SyncLeakyBucket
+        token_estimate: Optional callable taking function arguments to estimate token/capacity amount dynamically
+        token_reconcile: Optional callable taking the function return value to reconcile actual tokens/capacity used
 
     Returns:
         A decorator that applies the rate limit to the function
@@ -60,8 +68,21 @@ def rate_limit[**P, R](
     def decorator(func: Callable[P, R]) -> Callable[P, R]:
         @wraps(func)
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
-            with bucket:
-                return func(*args, **kwargs)
+            if token_estimate is None and token_reconcile is None:
+                with bucket:
+                    return func(*args, **kwargs)
+
+            estimated = (
+                token_estimate(*args, **kwargs) if token_estimate is not None else 1.0
+            )
+            bucket.acquire(amount=estimated)
+            result = func(*args, **kwargs)
+
+            if token_reconcile is not None:
+                actual = token_reconcile(result)
+                bucket.reconcile(actual=actual, estimated=estimated)
+
+            return result
 
         return wrapper
 
@@ -78,6 +99,8 @@ def async_rate_limit[**P, R](
     seconds: float = 1,
     max_concurrent: int | None = None,
     bucket_cls: type[AsyncRateLimit] = AsyncLeakyBucket,
+    token_estimate: Callable[P, float] | None = None,
+    token_reconcile: Callable[[R], float] | None = None,
 ) -> Callable[[Callable[P, Awaitable[R]]], Callable[P, Awaitable[R]]]: ...
 
 
@@ -89,6 +112,8 @@ def async_rate_limit[**P, R](
     seconds: float = 1,
     max_concurrent: int | None = None,
     bucket_cls: type[AsyncRateLimit] = AsyncLeakyBucket,
+    token_estimate: Callable[P, float] | None = None,
+    token_reconcile: Callable[[R], float] | None = None,
 ) -> Callable[P, Awaitable[R]]: ...
 
 
@@ -99,18 +124,22 @@ def async_rate_limit[**P, R](
     seconds: float = 1,
     max_concurrent: int | None = None,
     bucket_cls: type[AsyncRateLimit] = AsyncLeakyBucket,
+    token_estimate: Callable[P, float] | None = None,
+    token_reconcile: Callable[[R], float] | None = None,
 ) -> (
     Callable[P, Awaitable[R]]
     | Callable[[Callable[P, Awaitable[R]]], Callable[P, Awaitable[R]]]
 ):
-    """Decorator to apply an asynchronous leaky bucket rate limit to a function.
+    """Decorator to apply an asynchronous rate limit to a function.
 
     Args:
-        _func: Function to apply the rate limit to the function
-        capacity: Maximum number of requests allowed in the bucket, defaults to 10
+        _func: Function to apply the rate limit to
+        capacity: Maximum number of requests/tokens allowed in the bucket, defaults to 10
         seconds: Time period in seconds for the bucket to refill, defaults to 1
         max_concurrent: Maximum number of concurrent requests allowed, defaults to None (no limit)
         bucket_cls: Bucket class, defaults to AsyncLeakyBucket
+        token_estimate: Optional callable taking function arguments to estimate token/capacity amount dynamically
+        token_reconcile: Optional callable taking the function return value to reconcile actual tokens/capacity used
 
     Returns:
         A decorator that applies the rate limit to the function
@@ -122,8 +151,21 @@ def async_rate_limit[**P, R](
     def decorator(func: Callable[P, Awaitable[R]]) -> Callable[P, Awaitable[R]]:
         @wraps(func)
         async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
-            async with bucket:
-                return await func(*args, **kwargs)
+            if token_estimate is None and token_reconcile is None:
+                async with bucket:
+                    return await func(*args, **kwargs)
+
+            estimated = (
+                token_estimate(*args, **kwargs) if token_estimate is not None else 1.0
+            )
+            await bucket.acquire(amount=estimated)
+            result = await func(*args, **kwargs)
+
+            if token_reconcile is not None:
+                actual = token_reconcile(result)
+                await bucket.reconcile(actual=actual, estimated=estimated)
+
+            return result
 
         return wrapper
 

--- a/limitor/base.py
+++ b/limitor/base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextlib import AbstractAsyncContextManager, AbstractContextManager
 from types import TracebackType
 from typing import Protocol
 
@@ -31,6 +32,25 @@ class SyncRateLimit(Protocol):
             amount: The amount of capacity to acquire, defaults to 1
         """
 
+    def acquire_ctx(self, amount: float = 1) -> AbstractContextManager[SyncRateLimit]:
+        """Parameterized context manager to acquire a specified amount of capacity
+
+        Args:
+            amount: The amount of capacity to acquire, defaults to 1
+
+        Returns:
+            A context manager yielding the rate limit instance
+        """
+        ...  # pyrefly: ignore
+
+    def reconcile(self, actual: float, estimated: float) -> None:
+        """Reconcile the actual tokens/capacity used against the estimated amount
+
+        Args:
+            actual: The actual amount of tokens/capacity used
+            estimated: The estimated amount of tokens/capacity previously acquired
+        """
+
     def __enter__(self) -> SyncRateLimit:
         """Enter the context manager, acquiring resources if necessary
 
@@ -39,7 +59,7 @@ class SyncRateLimit(Protocol):
         Returns:
             An instance of the rate limit context manager
         """
-        ...  # pylint: disable=unnecessary-ellipsis
+        ...  # pyrefly: ignore
 
     def __exit__(
         self,
@@ -76,6 +96,28 @@ class AsyncRateLimit(Protocol):
             timeout: Optional timeout in seconds for the acquire operation
         """
 
+    def acquire_ctx(
+        self, amount: float = 1, timeout: float | None = None
+    ) -> AbstractAsyncContextManager[AsyncRateLimit]:
+        """Parameterized async context manager to acquire a specified amount of capacity
+
+        Args:
+            amount: The amount of capacity to acquire, defaults to 1
+            timeout: Optional timeout in seconds for the acquire operation
+
+        Returns:
+            An async context manager yielding the rate limit instance
+        """
+        ...  # pyrefly: ignore
+
+    async def reconcile(self, actual: float, estimated: float) -> None:
+        """Reconcile the actual tokens/capacity used against the estimated amount
+
+        Args:
+            actual: The actual amount of tokens/capacity used
+            estimated: The estimated amount of tokens/capacity previously acquired
+        """
+
     async def __aenter__(self) -> AsyncRateLimit:
         """Enter the context manager, acquiring resources if necessary
 
@@ -84,7 +126,7 @@ class AsyncRateLimit(Protocol):
         Returns:
             An instance of the rate limit context manager
         """
-        ...  # pylint: disable=unnecessary-ellipsis
+        ...  # pyrefly: ignore
 
     async def __aexit__(
         self,

--- a/limitor/extra/leaky_bucket/core.py
+++ b/limitor/extra/leaky_bucket/core.py
@@ -158,7 +158,7 @@ class AsyncLeakyBucket:
     @asynccontextmanager
     async def acquire_ctx(
         self, amount: float = 1, timeout: float | None = None
-    ) -> AsyncGenerator[AsyncLeakyBucket, None]:
+    ) -> AsyncGenerator[AsyncLeakyBucket]:
         """Async context manager that acquires a specific amount of capacity.
 
         Args:
@@ -166,7 +166,7 @@ class AsyncLeakyBucket:
             timeout: Optional timeout in seconds for the acquire operation
 
         Yields:
-            AsyncLeakyBucket: The AsyncLeakyBucket instance
+            AsyncGenerator[AsyncLeakyBucket]: The AsyncLeakyBucket instance
         """
         await self.acquire(amount=amount, timeout=timeout)
         try:

--- a/limitor/extra/leaky_bucket/core.py
+++ b/limitor/extra/leaky_bucket/core.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import time
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 from types import TracebackType
 from typing import Any
 
@@ -152,6 +154,39 @@ class AsyncLeakyBucket:
 
         await self._queue.put(None)  # Sentinel value
         await self._worker_task
+
+    @asynccontextmanager
+    async def acquire_ctx(
+        self, amount: float = 1, timeout: float | None = None
+    ) -> AsyncGenerator[AsyncLeakyBucket, None]:
+        """Async context manager that acquires a specific amount of capacity.
+
+        Args:
+            amount: The amount of capacity to acquire, defaults to 1
+            timeout: Optional timeout in seconds for the acquire operation
+
+        Yields:
+            AsyncLeakyBucket: The AsyncLeakyBucket instance
+        """
+        await self.acquire(amount=amount, timeout=timeout)
+        try:
+            yield self
+        finally:
+            pass
+
+    async def reconcile(self, actual: float, estimated: float) -> None:
+        """Reconcile the actual tokens/capacity used against the estimated amount.
+
+        Args:
+            actual: The actual amount of tokens/capacity used
+            estimated: The estimated amount of tokens/capacity previously acquired
+        """
+        diff = actual - estimated
+        if diff > 0:
+            await self.acquire(amount=diff)
+        elif diff < 0:
+            self._leak()
+            self._bucket_level = max(0.0, self._bucket_level + diff)
 
     async def __aenter__(self) -> AsyncLeakyBucket:
         """Enter the context manager, acquiring resources if necessary"""

--- a/limitor/generic_cell_rate/core.py
+++ b/limitor/generic_cell_rate/core.py
@@ -85,7 +85,7 @@ class SyncVirtualSchedulingGCRA:
             amount: The amount of capacity to acquire, defaults to 1
 
         Yields:
-            SyncVirtualSchedulingGCRA: The SyncVirtualSchedulingGCRA instance
+            Generator[SyncVirtualSchedulingGCRA]: The SyncVirtualSchedulingGCRA instance
         """
         self.acquire(amount=amount)
         try:
@@ -202,7 +202,7 @@ class SyncLeakyBucketGCRA:
             amount: The amount of capacity to acquire, defaults to 1
 
         Yields:
-            SyncLeakyBucketGCRA: The SyncLeakyBucketGCRA instance
+            Generator[SyncLeakyBucketGCRA]: The SyncLeakyBucketGCRA instance
         """
         self.acquire(amount=amount)
         try:
@@ -374,7 +374,7 @@ class AsyncVirtualSchedulingGCRA:
             timeout: Optional timeout in seconds for the acquire operation
 
         Yields:
-            AsyncVirtualSchedulingGCRA: The AsyncVirtualSchedulingGCRA instance
+            AsyncGenerator[AsyncVirtualSchedulingGCRA]: The AsyncVirtualSchedulingGCRA instance
         """
         await self.acquire(amount=amount, timeout=timeout)
         try:
@@ -550,7 +550,7 @@ class AsyncLeakyBucketGCRA:
             timeout: Optional timeout in seconds for the acquire operation
 
         Yields:
-            AsyncLeakyBucketGCRA: The AsyncLeakyBucketGCRA instance
+            AsyncGenerator[AsyncLeakyBucketGCRA]: The AsyncLeakyBucketGCRA instance
         """
         await self.acquire(amount=amount, timeout=timeout)
         try:

--- a/limitor/generic_cell_rate/core.py
+++ b/limitor/generic_cell_rate/core.py
@@ -10,7 +10,13 @@ from __future__ import annotations
 import asyncio
 import threading
 import time
-from contextlib import AbstractAsyncContextManager, nullcontext
+from collections.abc import AsyncGenerator, Generator
+from contextlib import (
+    AbstractAsyncContextManager,
+    asynccontextmanager,
+    contextmanager,
+    nullcontext,
+)
 from types import TracebackType
 from typing import Any
 
@@ -70,6 +76,37 @@ class SyncVirtualSchedulingGCRA:
                 time.sleep(delay)
 
             self._tat = max(t_a, self._tat) + amount * self.T
+
+    @contextmanager
+    def acquire_ctx(self, amount: float = 1) -> Generator[SyncVirtualSchedulingGCRA]:
+        """Context manager that acquires a specific amount of capacity.
+
+        Args:
+            amount: The amount of capacity to acquire, defaults to 1
+
+        Yields:
+            SyncVirtualSchedulingGCRA: The SyncVirtualSchedulingGCRA instance
+        """
+        self.acquire(amount=amount)
+        try:
+            yield self
+        finally:
+            pass
+
+    def reconcile(self, actual: float, estimated: float) -> None:
+        """Reconcile the actual tokens/capacity used against the estimated amount.
+
+        Args:
+            actual: The actual amount of tokens/capacity used
+            estimated: The estimated amount of tokens/capacity previously acquired
+        """
+        diff = actual - estimated
+        if diff > 0:
+            self.acquire(amount=diff)
+        elif diff < 0:
+            with self._lock:
+                if self._tat is not None:
+                    self._tat = max(time.monotonic(), self._tat + diff * self.T)
 
     def __enter__(self) -> SyncVirtualSchedulingGCRA:
         """Enter the context manager, acquiring resources if necessary
@@ -156,6 +193,41 @@ class SyncLeakyBucketGCRA:
 
             self._bucket_level = max(0.0, self._bucket_level) + amount * self.T
             self._last_leak = t_a
+
+    @contextmanager
+    def acquire_ctx(self, amount: float = 1) -> Generator[SyncLeakyBucketGCRA]:
+        """Context manager that acquires a specific amount of capacity.
+
+        Args:
+            amount: The amount of capacity to acquire, defaults to 1
+
+        Yields:
+            SyncLeakyBucketGCRA: The SyncLeakyBucketGCRA instance
+        """
+        self.acquire(amount=amount)
+        try:
+            yield self
+        finally:
+            pass
+
+    def reconcile(self, actual: float, estimated: float) -> None:
+        """Reconcile the actual tokens/capacity used against the estimated amount.
+
+        Args:
+            actual: The actual amount of tokens/capacity used
+            estimated: The estimated amount of tokens/capacity previously acquired
+        """
+        diff = actual - estimated
+        if diff > 0:
+            self.acquire(amount=diff)
+        elif diff < 0:
+            with self._lock:
+                t_a = time.monotonic()
+                if self._last_leak is not None:
+                    elapsed = t_a - self._last_leak
+                    self._bucket_level = max(0.0, self._bucket_level - elapsed)
+                    self._last_leak = t_a
+                self._bucket_level = max(0.0, self._bucket_level + diff * self.T)
 
     def __enter__(self) -> SyncLeakyBucketGCRA:
         """Enter the context manager, acquiring resources if necessary
@@ -290,6 +362,40 @@ class AsyncVirtualSchedulingGCRA:
                 ) from error
         else:
             await self._semaphore_acquire(amount)
+
+    @asynccontextmanager
+    async def acquire_ctx(
+        self, amount: float = 1, timeout: float | None = None
+    ) -> AsyncGenerator[AsyncVirtualSchedulingGCRA]:
+        """Async context manager that acquires a specific amount of capacity.
+
+        Args:
+            amount: The amount of capacity to acquire, defaults to 1
+            timeout: Optional timeout in seconds for the acquire operation
+
+        Yields:
+            AsyncVirtualSchedulingGCRA: The AsyncVirtualSchedulingGCRA instance
+        """
+        await self.acquire(amount=amount, timeout=timeout)
+        try:
+            yield self
+        finally:
+            pass
+
+    async def reconcile(self, actual: float, estimated: float) -> None:
+        """Reconcile the actual tokens/capacity used against the estimated amount.
+
+        Args:
+            actual: The actual amount of tokens/capacity used
+            estimated: The estimated amount of tokens/capacity previously acquired
+        """
+        diff = actual - estimated
+        if diff > 0:
+            await self.acquire(amount=diff)
+        elif diff < 0:
+            async with self._lock:
+                if self._tat is not None:
+                    self._tat = max(time.monotonic(), self._tat + diff * self.T)
 
     async def __aenter__(self) -> AsyncVirtualSchedulingGCRA:
         """Enter the context manager, acquiring resources if necessary
@@ -432,6 +538,44 @@ class AsyncLeakyBucketGCRA:
                 ) from error
         else:
             await self._semaphore_acquire(amount)
+
+    @asynccontextmanager
+    async def acquire_ctx(
+        self, amount: float = 1, timeout: float | None = None
+    ) -> AsyncGenerator[AsyncLeakyBucketGCRA]:
+        """Async context manager that acquires a specific amount of capacity.
+
+        Args:
+            amount: The amount of capacity to acquire, defaults to 1
+            timeout: Optional timeout in seconds for the acquire operation
+
+        Yields:
+            AsyncLeakyBucketGCRA: The AsyncLeakyBucketGCRA instance
+        """
+        await self.acquire(amount=amount, timeout=timeout)
+        try:
+            yield self
+        finally:
+            pass
+
+    async def reconcile(self, actual: float, estimated: float) -> None:
+        """Reconcile the actual tokens/capacity used against the estimated amount.
+
+        Args:
+            actual: The actual amount of tokens/capacity used
+            estimated: The estimated amount of tokens/capacity previously acquired
+        """
+        diff = actual - estimated
+        if diff > 0:
+            await self.acquire(amount=diff)
+        elif diff < 0:
+            async with self._lock:
+                t_a = time.monotonic()
+                if self._last_leak is not None:
+                    elapsed = t_a - self._last_leak
+                    self._bucket_level = max(0.0, self._bucket_level - elapsed)
+                    self._last_leak = t_a
+                self._bucket_level = max(0.0, self._bucket_level + diff * self.T)
 
     async def __aenter__(self) -> AsyncLeakyBucketGCRA:
         """Enter the context manager, acquiring resources if necessary

--- a/limitor/leaky_bucket/core.py
+++ b/limitor/leaky_bucket/core.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 import asyncio
 import threading
 import time
-from contextlib import AbstractAsyncContextManager, nullcontext
+from collections.abc import AsyncGenerator, Generator
+from contextlib import (
+    AbstractAsyncContextManager,
+    asynccontextmanager,
+    contextmanager,
+    nullcontext,
+)
 from types import TracebackType
 from typing import Any
 
@@ -84,6 +90,37 @@ class SyncLeakyBucket:
                 capacity_info = self.capacity_info(amount=amount)
 
             self._bucket_level += amount
+
+    @contextmanager
+    def acquire_ctx(self, amount: float = 1) -> Generator[SyncLeakyBucket]:
+        """Context manager that acquires a specific amount of capacity.
+
+        Args:
+            amount: The amount of capacity to acquire, defaults to 1
+
+        Yields:
+            SyncLeakyBucket: The SyncLeakyBucket instance
+        """
+        self.acquire(amount=amount)
+        try:
+            yield self
+        finally:
+            pass
+
+    def reconcile(self, actual: float, estimated: float) -> None:
+        """Reconcile the actual tokens/capacity used against the estimated amount.
+
+        Args:
+            actual: The actual amount of tokens/capacity used
+            estimated: The estimated amount of tokens/capacity previously acquired
+        """
+        diff = actual - estimated
+        if diff > 0:
+            self.acquire(amount=diff)
+        elif diff < 0:
+            with self._lock:
+                self._leak()
+                self._bucket_level = max(0.0, self._bucket_level + diff)
 
     def __enter__(self) -> SyncLeakyBucket:
         """Enter the context manager, acquiring resources if necessary"""
@@ -219,6 +256,40 @@ class AsyncLeakyBucket:
                 ) from error
         else:
             await self._semaphore_acquire(amount)
+
+    @asynccontextmanager
+    async def acquire_ctx(
+        self, amount: float = 1, timeout: float | None = None
+    ) -> AsyncGenerator[AsyncLeakyBucket]:
+        """Async context manager that acquires a specific amount of capacity.
+
+        Args:
+            amount: The amount of capacity to acquire, defaults to 1
+            timeout: Optional timeout in seconds for the acquire operation
+
+        Yields:
+            AsyncLeakyBucket: The AsyncLeakyBucket instance
+        """
+        await self.acquire(amount=amount, timeout=timeout)
+        try:
+            yield self
+        finally:
+            pass
+
+    async def reconcile(self, actual: float, estimated: float) -> None:
+        """Reconcile the actual tokens/capacity used against the estimated amount.
+
+        Args:
+            actual: The actual amount of tokens/capacity used
+            estimated: The estimated amount of tokens/capacity previously acquired
+        """
+        diff = actual - estimated
+        if diff > 0:
+            await self.acquire(amount=diff)
+        elif diff < 0:
+            async with self._lock:
+                self._leak()
+                self._bucket_level = max(0.0, self._bucket_level + diff)
 
     async def __aenter__(self) -> AsyncLeakyBucket:
         """Enter the context manager, acquiring resources if necessary"""

--- a/limitor/leaky_bucket/core.py
+++ b/limitor/leaky_bucket/core.py
@@ -99,7 +99,7 @@ class SyncLeakyBucket:
             amount: The amount of capacity to acquire, defaults to 1
 
         Yields:
-            SyncLeakyBucket: The SyncLeakyBucket instance
+            Generator[SyncLeakyBucket]: The SyncLeakyBucket instance
         """
         self.acquire(amount=amount)
         try:
@@ -268,7 +268,7 @@ class AsyncLeakyBucket:
             timeout: Optional timeout in seconds for the acquire operation
 
         Yields:
-            AsyncLeakyBucket: The AsyncLeakyBucket instance
+            AsyncGenerator[AsyncLeakyBucket]: The AsyncLeakyBucket instance
         """
         await self.acquire(amount=amount, timeout=timeout)
         try:

--- a/limitor/token_bucket/core.py
+++ b/limitor/token_bucket/core.py
@@ -102,7 +102,7 @@ class SyncTokenBucket:
             amount: The amount of capacity to acquire, defaults to 1
 
         Yields:
-            SyncTokenBucket: The SyncTokenBucket instance
+            Generator[SyncTokenBucket]: The SyncTokenBucket instance
         """
         self.acquire(amount=amount)
         try:
@@ -275,7 +275,7 @@ class AsyncTokenBucket:
             timeout: Optional timeout in seconds for the acquire operation
 
         Yields:
-            AsyncTokenBucket: The AsyncTokenBucket instance
+            AsyncGenerator[AsyncTokenBucket]: The AsyncTokenBucket instance
         """
         await self.acquire(amount=amount, timeout=timeout)
         try:

--- a/limitor/token_bucket/core.py
+++ b/limitor/token_bucket/core.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 import asyncio
 import threading
 import time
-from contextlib import AbstractAsyncContextManager, nullcontext
+from collections.abc import AsyncGenerator, Generator
+from contextlib import (
+    AbstractAsyncContextManager,
+    asynccontextmanager,
+    contextmanager,
+    nullcontext,
+)
 from types import TracebackType
 from typing import Any
 
@@ -87,6 +93,37 @@ class SyncTokenBucket:
                 capacity_info = self.capacity_info(amount=amount)
 
             self._bucket_level -= amount
+
+    @contextmanager
+    def acquire_ctx(self, amount: float = 1) -> Generator[SyncTokenBucket]:
+        """Context manager that acquires a specific amount of capacity.
+
+        Args:
+            amount: The amount of capacity to acquire, defaults to 1
+
+        Yields:
+            SyncTokenBucket: The SyncTokenBucket instance
+        """
+        self.acquire(amount=amount)
+        try:
+            yield self
+        finally:
+            pass
+
+    def reconcile(self, actual: float, estimated: float) -> None:
+        """Reconcile the actual tokens/capacity used against the estimated amount.
+
+        Args:
+            actual: The actual amount of tokens/capacity used
+            estimated: The estimated amount of tokens/capacity previously acquired
+        """
+        diff = actual - estimated
+        if diff > 0:
+            self.acquire(amount=diff)
+        elif diff < 0:
+            with self._lock:
+                self._fill()
+                self._bucket_level = min(self.capacity, self._bucket_level - diff)
 
     def __enter__(self) -> SyncTokenBucket:
         """Enter the context manager, acquiring resources if necessary"""
@@ -226,6 +263,40 @@ class AsyncTokenBucket:
                 ) from error
         else:
             await self._semaphore_acquire(amount)
+
+    @asynccontextmanager
+    async def acquire_ctx(
+        self, amount: float = 1, timeout: float | None = None
+    ) -> AsyncGenerator[AsyncTokenBucket]:
+        """Async context manager that acquires a specific amount of capacity.
+
+        Args:
+            amount: The amount of capacity to acquire, defaults to 1
+            timeout: Optional timeout in seconds for the acquire operation
+
+        Yields:
+            AsyncTokenBucket: The AsyncTokenBucket instance
+        """
+        await self.acquire(amount=amount, timeout=timeout)
+        try:
+            yield self
+        finally:
+            pass
+
+    async def reconcile(self, actual: float, estimated: float) -> None:
+        """Reconcile the actual tokens/capacity used against the estimated amount.
+
+        Args:
+            actual: The actual amount of tokens/capacity used
+            estimated: The estimated amount of tokens/capacity previously acquired
+        """
+        diff = actual - estimated
+        if diff > 0:
+            await self.acquire(amount=diff)
+        elif diff < 0:
+            async with self._lock:
+                self._fill()
+                self._bucket_level = min(self.capacity, self._bucket_level - diff)
 
     async def __aenter__(self) -> AsyncTokenBucket:
         """Enter the context manager, acquiring resources if necessary"""

--- a/tests/integration/test_integration_async.py
+++ b/tests/integration/test_integration_async.py
@@ -240,6 +240,107 @@ async def test_context_manager_calls_acquire(
 
 
 @pytest.mark.asyncio
+class TestReconcileOverestimate:
+    """Tests for reconcile refund behavior (actual < estimated) per bucket type"""
+
+    async def test_token_bucket_refunds(self, bucket_config: BucketConfig) -> None:
+        """Token bucket refund adds back to _bucket_level"""
+        tb = AsyncTokenBucket(bucket_config=bucket_config)
+        tb._bucket_level = 0.5
+        await tb.reconcile(actual=2, estimated=3)
+        assert tb._bucket_level > 0.5
+
+    async def test_leaky_bucket_refunds(self, bucket_config: BucketConfig) -> None:
+        """Leaky bucket refund subtracts from _bucket_level"""
+        lb = AsyncLeakyBucket(bucket_config=bucket_config)
+        lb._bucket_level = 1.5
+        await lb.reconcile(actual=1, estimated=2)
+        assert lb._bucket_level < 1.5
+
+    async def test_gcra_vs_refunds_when_acquired(
+        self, bucket_config: BucketConfig
+    ) -> None:
+        """GCRA virtual-scheduling refund pulls TAT backward after an acquire"""
+        gcra_vs = AsyncVirtualSchedulingGCRA(bucket_config=bucket_config)
+        await gcra_vs.acquire(1)
+        prev_tat = gcra_vs._tat
+        await gcra_vs.reconcile(actual=0.5, estimated=1.0)
+        assert gcra_vs._tat is not None
+        assert prev_tat is not None
+        assert gcra_vs._tat < prev_tat
+
+    async def test_gcra_vs_refunds_when_not_acquired(
+        self, bucket_config: BucketConfig
+    ) -> None:
+        """GCRA virtual-scheduling refund preserves None _tat when never acquired"""
+        gcra_vs = AsyncVirtualSchedulingGCRA(bucket_config=bucket_config)
+        await gcra_vs.reconcile(actual=0.5, estimated=1.0)
+        assert gcra_vs._tat is None
+
+    async def test_gcra_lb_refunds_when_acquired(
+        self, bucket_config: BucketConfig
+    ) -> None:
+        """GCRA leaky-bucket refund reduces _bucket_level after an acquire"""
+        gcra_lb = AsyncLeakyBucketGCRA(bucket_config=bucket_config)
+        await gcra_lb.acquire(1)
+        await gcra_lb.reconcile(actual=0.5, estimated=1.0)
+        assert gcra_lb._bucket_level < 1.0
+
+    async def test_gcra_lb_refunds_when_not_acquired(
+        self, bucket_config: BucketConfig
+    ) -> None:
+        """GCRA leaky-bucket refund preserves state when never acquired"""
+        gcra_lb = AsyncLeakyBucketGCRA(bucket_config=bucket_config)
+        await gcra_lb.reconcile(actual=0.5, estimated=1.0)
+        assert gcra_lb._last_leak is None
+        assert gcra_lb._bucket_level == 0.0
+
+    async def test_extra_leaky_bucket_refunds(
+        self, bucket_config: BucketConfig
+    ) -> None:
+        """Extra leaky bucket refund subtracts from _bucket_level"""
+        lb_extra = AsyncLeakyBucketExtra(bucket_config=bucket_config)
+        lb_extra._bucket_level = 1.5
+        await lb_extra.reconcile(actual=1, estimated=2)
+        assert lb_extra._bucket_level < 1.5
+
+
+@pytest.mark.asyncio
+async def test_async_decorator_token_estimate_and_reconcile() -> None:
+    """Test async decorator with token_estimate and token_reconcile hooks"""
+
+    @async_rate_limit(
+        capacity=100,
+        seconds=1,
+        bucket_cls=AsyncTokenBucket,
+        token_estimate=lambda prompt, **kw: len(prompt) * 2,
+        token_reconcile=lambda res: res["tokens"],
+    )
+    async def call_llm(prompt: str):
+        return {"content": "ok", "tokens": len(prompt) * 3}
+
+    res = await call_llm("hello")
+    assert res == {"content": "ok", "tokens": 15}
+
+
+@pytest.mark.asyncio
+async def test_async_decorator_token_estimate_only() -> None:
+    """Test async decorator with token_estimate only (no token_reconcile)"""
+
+    @async_rate_limit(
+        capacity=100,
+        seconds=1,
+        bucket_cls=AsyncTokenBucket,
+        token_estimate=lambda prompt, **kw: len(prompt) * 2,
+    )
+    async def call_llm(prompt: str):
+        return f"result: {prompt}"
+
+    res = await call_llm("hello")
+    assert res == "result: hello"
+
+
+@pytest.mark.asyncio
 async def test_shutdown_without_starting_worker(bucket_config: BucketConfig) -> None:
     """Shutdown should be a no-op if the worker was never started"""
     bucket = AsyncLeakyBucketExtra(bucket_config)

--- a/tests/integration/test_integration_sync.py
+++ b/tests/integration/test_integration_sync.py
@@ -180,3 +180,88 @@ def test_context_manager_calls_acquire(
 
     assert len(sleep_calls) >= 4
     assert value_list == [1, 2, 3, 4, 5, 6]  # assert order is correct
+
+
+class TestReconcileOverestimate:
+    """Tests for reconcile refund behavior (actual < estimated) per bucket type"""
+
+    def test_token_bucket_refunds(self, bucket_config: BucketConfig) -> None:
+        """Token bucket refund adds back to _bucket_level"""
+        tb = SyncTokenBucket(bucket_config=bucket_config)
+        tb._bucket_level = 0.5
+        tb.reconcile(actual=2, estimated=3)
+        assert tb._bucket_level > 0.5
+
+    def test_leaky_bucket_refunds(self, bucket_config: BucketConfig) -> None:
+        """Leaky bucket refund subtracts from _bucket_level"""
+        lb = SyncLeakyBucket(bucket_config=bucket_config)
+        lb._bucket_level = 1.5
+        lb.reconcile(actual=1, estimated=2)
+        assert lb._bucket_level < 1.5
+
+    def test_gcra_vs_refunds_when_acquired(self, bucket_config: BucketConfig) -> None:
+        """GCRA virtual-scheduling refund pulls TAT backward after an acquire"""
+        gcra_vs = SyncVirtualSchedulingGCRA(bucket_config=bucket_config)
+        gcra_vs.acquire(1)
+        prev_tat = gcra_vs._tat
+        gcra_vs.reconcile(actual=0.5, estimated=1.0)
+        assert gcra_vs._tat is not None
+        assert prev_tat is not None
+        assert gcra_vs._tat < prev_tat
+
+    def test_gcra_vs_refunds_when_not_acquired(
+        self, bucket_config: BucketConfig
+    ) -> None:
+        """GCRA virtual-scheduling refund preserves None _tat when never acquired"""
+        gcra_vs = SyncVirtualSchedulingGCRA(bucket_config=bucket_config)
+        gcra_vs.reconcile(actual=0.5, estimated=1.0)
+        assert gcra_vs._tat is None
+
+    def test_gcra_lb_refunds_when_acquired(self, bucket_config: BucketConfig) -> None:
+        """GCRA leaky-bucket refund reduces _bucket_level after an acquire"""
+        gcra_lb = SyncLeakyBucketGCRA(bucket_config=bucket_config)
+        gcra_lb.acquire(1)
+        gcra_lb.reconcile(actual=0.5, estimated=1.0)
+        assert gcra_lb._bucket_level < 1.0
+
+    def test_gcra_lb_refunds_when_not_acquired(
+        self, bucket_config: BucketConfig
+    ) -> None:
+        """GCRA leaky-bucket refund preserves state when never acquired"""
+        gcra_lb = SyncLeakyBucketGCRA(bucket_config=bucket_config)
+        gcra_lb.reconcile(actual=0.5, estimated=1.0)
+        assert gcra_lb._last_leak is None
+        assert gcra_lb._bucket_level == 0.0
+
+
+def test_decorator_token_estimate_and_reconcile() -> None:
+    """Test decorator with token_estimate and token_reconcile hooks"""
+
+    @rate_limit(
+        capacity=100,
+        seconds=1,
+        bucket_cls=SyncTokenBucket,
+        token_estimate=lambda prompt, **kw: len(prompt) * 2,
+        token_reconcile=lambda res: res["tokens"],
+    )
+    def call_llm(prompt: str):
+        return {"content": "ok", "tokens": len(prompt) * 3}
+
+    res = call_llm("hello")
+    assert res == {"content": "ok", "tokens": 15}
+
+
+def test_decorator_token_estimate_only() -> None:
+    """Test decorator with token_estimate only (no token_reconcile)"""
+
+    @rate_limit(
+        capacity=100,
+        seconds=1,
+        bucket_cls=SyncTokenBucket,
+        token_estimate=lambda prompt, **kw: len(prompt) * 2,
+    )
+    def call_llm(prompt: str):
+        return f"result: {prompt}"
+
+    res = call_llm("hello")
+    assert res == "result: hello"

--- a/tests/unit/test_async.py
+++ b/tests/unit/test_async.py
@@ -35,6 +35,32 @@ def bucket_cls(request: pytest.FixtureRequest, bucket_config: BucketConfig) -> A
 class TestAmountValidation:
     """Tests for amount validation in async bucket implementations"""
 
+    @patch(
+        "limitor.utils.validate_amount",
+        side_effect=ValueError("Cannot acquire more than the bucket's capacity: 2"),
+    )
+    async def test_acquire_rejects_amount_greater_than_capacity(
+        self, mocked_validate_amount: MagicMock, bucket_cls: AsyncRateLimit
+    ) -> None:
+        """Verify that requesting more than the configured capacity raises ValueError"""
+        with pytest.raises(
+            ValueError, match=r"Cannot acquire more than the bucket's capacity: 2"
+        ):
+            await bucket_cls.acquire(3)
+
+    @patch(
+        "limitor.utils.validate_amount",
+        side_effect=ValueError("Cannot acquire less than 0 amount with amount: -1"),
+    )
+    async def test_acquire_rejects_amount_less_than_zero(
+        self, mocked_validate_amount: MagicMock, bucket_cls: AsyncRateLimit
+    ) -> None:
+        """Verify that requesting a negative amount raises ValueError"""
+        with pytest.raises(
+            ValueError, match=r"Cannot acquire less than 0 amount with amount: -1"
+        ):
+            await bucket_cls.acquire(-1)
+
     @pytest.mark.parametrize("bucket_cls", [AsyncLeakyBucket, AsyncTokenBucket])
     @patch("asyncio.sleep", new_callable=AsyncMock)
     @patch("time.monotonic", side_effect=[0, 0, 0, 0, 0.1])
@@ -351,9 +377,6 @@ class TestAsyncFeatures:
         mock_locked.__aexit__ = AsyncMock()
         bucket._lock = mock_locked  # type: ignore
 
-        # Patch asyncio.sleep to avoid actual waiting
-        # Patch time.monotonic to ensure deterministic behavior for GCRA
-
         await bucket.acquire(amount=1)
 
         mock_locked.__aenter__.assert_called_once()
@@ -377,8 +400,6 @@ class TestAsyncFeatures:
         """Test the lifecycle of the worker task in AsyncLeakyBucketExtra"""
         bucket = AsyncLeakyBucketExtra(bucket_config)
         assert bucket._worker_task is None
-
-        # We need to mock queue.put and future to avoid actual execution
 
         # Use a real future but resolve it immediately
         loop = asyncio.get_running_loop()
@@ -488,7 +509,7 @@ async def test_acquire_wait_time_less_than_or_equal_to_zero(
     bucket_cls_wait: type[AsyncRateLimit],
     bucket_config: BucketConfig,
 ) -> None:
-    """Test the branch where wait_time <= 0 inside the acquire loop"""
+    """Test the branch where wait_time <= 0 inside the acquire loop does not sleep"""
     bucket = bucket_cls_wait(bucket_config=bucket_config)
     with patch.object(bucket, "capacity_info") as mocked_capacity_info:
         mocked_capacity_info.side_effect = [
@@ -496,4 +517,44 @@ async def test_acquire_wait_time_less_than_or_equal_to_zero(
             Capacity(has_capacity=True, needed_capacity=0),
         ]
         await bucket.acquire(1)
-        mocked_sleep.assert_not_called()
+
+    mocked_sleep.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_acquire_ctx_custom_amount(
+    bucket_cls: AsyncRateLimit, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test acquire_ctx context manager acquires custom amount asynchronously"""
+    mocked_acquire = AsyncMock()
+    monkeypatch.setattr(bucket_cls, "acquire", mocked_acquire)
+
+    async with bucket_cls.acquire_ctx(amount=1.5, timeout=2.0) as ctx:
+        assert ctx is bucket_cls
+
+    mocked_acquire.assert_awaited_once_with(amount=1.5, timeout=2.0)
+
+
+@pytest.mark.asyncio
+class TestReconcile:
+    """Tests for the `reconcile` method of async bucket implementations"""
+
+    async def test_reconcile_underestimate_calls_acquire(
+        self, bucket_cls: AsyncRateLimit, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test async reconcile when actual > estimated acquires the difference"""
+        mocked_acquire = AsyncMock()
+        monkeypatch.setattr(bucket_cls, "acquire", mocked_acquire)
+
+        await bucket_cls.reconcile(actual=10, estimated=6)
+        mocked_acquire.assert_awaited_once_with(amount=4)
+
+    async def test_reconcile_equal_amount_no_op(
+        self, bucket_cls: AsyncRateLimit, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test async reconcile when actual == estimated does not call acquire"""
+        mocked_acquire = AsyncMock()
+        monkeypatch.setattr(bucket_cls, "acquire", mocked_acquire)
+
+        await bucket_cls.reconcile(actual=5, estimated=5)
+        mocked_acquire.assert_not_called()

--- a/tests/unit/test_sync.py
+++ b/tests/unit/test_sync.py
@@ -25,7 +25,7 @@ from limitor.token_bucket.core import SyncTokenBucket
 )
 def bucket_cls(request: pytest.FixtureRequest, bucket_config: BucketConfig) -> Any:
     """Fixture that provides bucket instances with capacity=2, seconds=0.2 for general tests"""
-    return request.param(bucket_config)  # like AsyncLeakyBucket(BucketConfig(...))
+    return request.param(bucket_config)  # like SyncLeakyBucket(BucketConfig(...))
 
 
 # test amount
@@ -325,10 +325,13 @@ def test_context_manager_calls_acquire_unit(
 
 
 @pytest.mark.parametrize("bucket_cls_wait", [SyncLeakyBucket, SyncTokenBucket])
+@patch("time.sleep")
 def test_acquire_wait_time_less_than_or_equal_to_zero(
-    bucket_cls_wait: type[SyncRateLimit], bucket_config: BucketConfig
+    mocked_sleep: MagicMock,
+    bucket_cls_wait: type[SyncRateLimit],
+    bucket_config: BucketConfig,
 ) -> None:
-    """Test the branch where wait_time <= 0 inside the acquire loop"""
+    """Test the branch where wait_time <= 0 inside the acquire loop does not sleep"""
     bucket = bucket_cls_wait(bucket_config=bucket_config)
     with patch.object(bucket, "capacity_info") as mocked_capacity_info:
         mocked_capacity_info.side_effect = [
@@ -336,3 +339,42 @@ def test_acquire_wait_time_less_than_or_equal_to_zero(
             Capacity(has_capacity=True, needed_capacity=0),
         ]
         bucket.acquire(1)
+
+    mocked_sleep.assert_not_called()
+
+
+def test_acquire_ctx_custom_amount(
+    bucket_cls: SyncRateLimit, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test acquire_ctx context manager acquires custom amount"""
+    mocked_acquire = MagicMock()
+    monkeypatch.setattr(bucket_cls, "acquire", mocked_acquire)
+
+    with bucket_cls.acquire_ctx(amount=1.5) as ctx:
+        assert ctx is bucket_cls
+
+    mocked_acquire.assert_called_once_with(amount=1.5)
+
+
+class TestReconcile:
+    """Tests for the `reconcile` method of sync bucket implementations"""
+
+    def test_reconcile_underestimate_calls_acquire(
+        self, bucket_cls: SyncRateLimit, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test reconcile when actual > estimated acquires the difference"""
+        mocked_acquire = MagicMock()
+        monkeypatch.setattr(bucket_cls, "acquire", mocked_acquire)
+
+        bucket_cls.reconcile(actual=10, estimated=6)
+        mocked_acquire.assert_called_once_with(amount=4)
+
+    def test_reconcile_equal_amount_no_op(
+        self, bucket_cls: SyncRateLimit, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test reconcile when actual == estimated does not call acquire"""
+        mocked_acquire = MagicMock()
+        monkeypatch.setattr(bucket_cls, "acquire", mocked_acquire)
+
+        bucket_cls.reconcile(actual=5, estimated=5)
+        mocked_acquire.assert_not_called()


### PR DESCRIPTION
# First-Class LLM Token Estimation, Reconciliation, and Parameterized Context Managers

## Problem

Previously, handling tokens required a custom wrapper that searched function keyword arguments for an amount parameter. This had several significant drawbacks:

• It was error-prone (positional arguments were silently ignored, causing dramatic under-counting).
• It coupled domain function signatures to the rate limiter's internal naming conventions.
• It could not account for actual tokens returned in an LLM API response (which are only known after the request completes).

## How we fix this problem?

This PR introduces native, first-class support for variable capacity and LLM token-based rate limiting across all synchronous and asynchronous algorithms. Developers can now:
1. Estimate Tokens Upfront (`token_estimate`): Dynamically calculate prompt tokens before making a request without modifying the function's parameter signature.
2. Reconcile Response Tokens (`token_reconcile`): Automatically debit excess tokens or refund unused tokens when the API response returns with exact token usage metadata (`response.usage.total_tokens`).
3. Use Parameterized Context Managers (`acquire_ctx` & `reconcile`): Directly acquire custom token counts and perform manual reconciliation in context manager workflows (`with bucket.acquire_ctx(amount=...):`).

## Why These Changes Were Made & Developer Experience (DevEx) Impact

1. Clean Separation of Concerns: Functions no longer need artificial amount parameters in their signature. Business functions remain completely unaware of the rate limiting layer.
2. True Two-Phase LLM Rate Limiting: Solves the fundamental LLM rate limiting challenge by estimating upfront to shape traffic and reconciling upon response to prevent token leakage or unfair over-throttling. This is similar to how other LLM inference infrastructure works like AWS Bedrock.
3. Total Symmetry: Decorators and Context Managers share the exact same mental model, parameters, and algorithms.
4. 100% Backward Compatible: Existing code using @rate_limit or with bucket: continues to work unchanged with standard amount=1 defaults.